### PR TITLE
bitstream-extraction_git.bb: Update MIT license file checksum

### DIFF
--- a/recipes-bsp/bitstream/bitstream-extraction_git.bb
+++ b/recipes-bsp/bitstream/bitstream-extraction_git.bb
@@ -1,7 +1,7 @@
 DESCRIPTION = "Recipe to extract bitstream"
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://${COREBASE}/LICENSE;md5=4d92cd373abda3937c2bc47fbc49d690"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 DEPENDS += "virtual/hdf"
 


### PR DESCRIPTION
LIC_FILES_CHKSUM was invalid and producing a warning:  

"WARNING: bitstream-extraction-git-r0 do_populate_lic: ${COREBASE}/LICENSE is not a valid license file, please use '${COMMON_LICENSE_DIR}/MIT' for a MIT License file in LIC_FILES_CHKSUM. This will become an error in the future"

Corrected the value for MIT license to remove the warning and prevent a future error.