### PR TITLE
Installation failed with HDF_BASE localy

### DIFF
--- a/recipes-bsp/hdf/external-hdf.bb
+++ b/recipes-bsp/hdf/external-hdf.bb
@@ -25,7 +25,7 @@ do_deploy() {
     if [ "${HDF_BASE}" = "git://" ]; then
         install -m 0644 ${WORKDIR}/git/${MACHINE}/${HDF_NAME} ${DEPLOYDIR}/Xilinx-${MACHINE}.hdf
     else
-        install -m 0644 ${WORKDIR}/${HDF_PATH} ${DEPLOYDIR}/Xilinx-${MACHINE}.hdf
+        install -m 0644 ${WORKDIR}/${HDF_PATH}/${HDF_NAME} ${DEPLOYDIR}/Xilinx-${MACHINE}.hdf
     fi
 }
 addtask do_deploy after do_install


### PR DESCRIPTION
Hi,
According to the readme I have added in my custom board definition :

HDF_BASE ?= "file://"
HDF_PATH ?= "/local/path/to/hdf/"
HDF_NAME ?= "custom_system.hdf"

But on my side the build task failed if the name is not set install function.
I have missed something here?

Cheers,
Nicolas