### PR TITLE
Patch for xilinx-bootbin providing boot.bin and layerdepends duplication

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -12,8 +12,6 @@ BBFILE_PRIORITY_xilinx-tools = "5"
 BBFILE_PATTERN_xilinx-tools = "^${LAYERDIR}/"
 
 LAYERDEPENDS_xilinx-tools  = "core xilinx meta-python"
-LAYERDEPENDS_xilinx-tools  += "meta-python"
-LAYERDEPENDS_xilinx-tools  += "xilinx"
 
 XLNX_SCRIPTS_DIR = "${LAYERDIR}/scripts/"
 

--- a/recipes-bsp/bootbin/xilinx-bootbin_1.0.bb
+++ b/recipes-bsp/bootbin/xilinx-bootbin_1.0.bb
@@ -102,6 +102,7 @@ do_deploy() {
     install -d ${DEPLOYDIR}
     install -m 0644 ${B}/BOOT.bin ${DEPLOYDIR}/${BOOTBIN_BASE_NAME}.bin
     ln -sf ${BOOTBIN_BASE_NAME}.bin ${DEPLOYDIR}/BOOT-${MACHINE}.bin
+    ln -sf ${BOOTBIN_BASE_NAME}.bin ${DEPLOYDIR}/boot.bin
 }
 addtask do_deploy before do_build after do_compile
 


### PR DESCRIPTION
This layer's definition repeats its dependencies.  It's not a bug, just a needless duplication of code.

The match for xilinx-bootbin ensures it deploys `boot.bin` since it's likely being built as the provider for `virtual/boot-bin`.  The way the `meta-xilinx` layer's `u-boot-zynq-uenv` recipe is written necessitates the link being lower-case `boot.bin` vs. `BOOT.bin` (the actual generated file name) so that it doesn't accidentally get inferred to be an FPGA bitstream file based on its extension.