### PR TITLE
xsctyaml.bbclass: Point libdir to the correct native path

### DIFF
--- a/classes/xsctyaml.bbclass
+++ b/classes/xsctyaml.bbclass
@@ -2,6 +2,9 @@ inherit python3native
 
 DEPENDS += "python3-pyyaml-native"
 
+# Since we're not inheriting native.bbclass, we need to set libdir to correctly point to the native libdir
+PYTHON_SITEPACKAGES_DIR = "${libdir_native}/${PYTHON_DIR}/site-packages"
+
 YAML_APP_CONFIG ?= ''
 YAML_BSP_CONFIG ?= ''
 YAML_FILE_PATH ?= ''


### PR DESCRIPTION
When target and native do not match, libdir may end up pointing to the
incorrect location. To fix this, we can set PYTHON_SITEPACKAGES_DIR to
point to libdir_native instead of libdir.

Fixes #25