### PR TITLE
ai-engine-driver: version 2.0 requires network access

### DIFF
--- a/recipes-bsp/ai-engine/ai-engine-driver_2.0.bb
+++ b/recipes-bsp/ai-engine/ai-engine-driver_2.0.bb
@@ -18,7 +18,7 @@ S = "${WORKDIR}/git"
 I = "${AIEDIR}/include"
 
 # Keep v1 as default for now.
-DEFAULT_PREFERENCE = "-1"
+COMPATIBLE_HOST = "${@bb.utils.contains('AIED_VERSION','2.0','.*','none',d)}"
 
 DEPENDS = "libmetal"
 RDEPENDS_${PN} = "libmetal"


### PR DESCRIPTION
The recipe uses AUTOREV and so needs network access while being
parsed even if the recipe will not be selected.  We disable parsing
unless AIED_VERSION = "2.0".  This could be done in local.conf

AIED_VERSION_pn-ai-engine-driver = "2.0"

is one way.

Signed-off-by: Joe Slater <joe.slater@windriver.com>