### PR TITLE
Update XILINX_VER_MAIN variable

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -15,7 +15,7 @@ LAYERDEPENDS_xilinx-tools  = "core xilinx meta-python"
 
 XLNX_SCRIPTS_DIR = "${LAYERDIR}/scripts/"
 
-XILINX_VER_MAIN ??= "2019.2"
+XILINX_VER_MAIN ??= "2020.1"
 SDK_LOCAL_CONF_WHITELIST_append = " XILINX_SDK_TOOLCHAIN XILINX_VER_MAIN"
 
 HOSTTOOLS += "ps"


### PR DESCRIPTION
Update the XILINX_VER_MAIN variable to 2020.1 on the `rel-v2020.1` branch.