### PR TITLE
libfpga: remove trailing slash from S

### DIFF
--- a/recipes-bsp/libfpga/libfpga_1.0.bb
+++ b/recipes-bsp/libfpga/libfpga_1.0.bb
@@ -14,7 +14,7 @@ COMPATIBLE_MACHINE = "^$"
 COMPATIBLE_MACHINE_zynqmp = "zynqmp"
 COMPATIBLE_MACHINE_versal = "versal"
 
-S = "${WORKDIR}/git/"
+S = "${WORKDIR}/git"
 
 inherit cmake
 


### PR DESCRIPTION
Fixes:
WARNING: libfpga_1.0.bb: Recipe libfpga sets S variable with trailing
slash, remove it.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>