### PR TITLE
create $pname/drivers dir by default

### DIFF
--- a/scripts/base-hsi.tcl
+++ b/scripts/base-hsi.tcl
@@ -47,6 +47,8 @@ proc set_hw_design {project hdf hdf_type} {
         	puts "$::errorInfo"
 	}
 
+	file mkdir $project/drivers
+
 	if { [catch {openhw $project/hardware_description.$hdf_type} res] } {
         	error "Failed to open hardware design \
                        $project/hardware_description.$hdf_type"


### PR DESCRIPTION
this is useful for the case when the drivers dir is not included in the xsa file for custom ip.  the project can still be extracted without causing trouble for the openhw command.