### PR TITLE
fpgamanager: replace /lib with ${nonarch_base_libdir}

### DIFF
--- a/classes/fpgamanager_custom.bbclass
+++ b/classes/fpgamanager_custom.bbclass
@@ -63,14 +63,14 @@ python devicetree_do_compile_append() {
 }
 
 do_install() {
-    install -d ${D}/lib/firmware/xilinx/${PN}/
-    install -Dm 0644 *.dtbo ${D}/lib/firmware/xilinx/${PN}/${PN}.dtbo
-    install -Dm 0644 ${PN}.bit.bin ${D}/lib/firmware/xilinx/${PN}/${PN}.bit.bin
+    install -d ${D}${nonarch_base_libdir}/firmware/xilinx/${PN}/
+    install -Dm 0644 *.dtbo ${D}${nonarch_base_libdir}/firmware/xilinx/${PN}/${PN}.dtbo
+    install -Dm 0644 ${PN}.bit.bin ${D}${nonarch_base_libdir}/firmware/xilinx/${PN}/${PN}.bit.bin
     if ls ${WORKDIR}/${XCL_PATH}/*.xclbin >/dev/null 2>&1; then
-        install -Dm 0644 ${WORKDIR}/${XCL_PATH}/*.xclbin ${D}/lib/firmware/xilinx/${PN}/${PN}.xclbin
+        install -Dm 0644 ${WORKDIR}/${XCL_PATH}/*.xclbin ${D}${nonarch_base_libdir}/firmware/xilinx/${PN}/${PN}.xclbin
     fi
 }
 
 do_deploy[noexec] = "1"
 
-FILES_${PN} += "/lib/firmware/xilinx/{PN}"
+FILES_${PN} += "${nonarch_base_libdir}/firmware/xilinx/{PN}"

--- a/classes/fpgamanager_dtg.bbclass
+++ b/classes/fpgamanager_dtg.bbclass
@@ -84,14 +84,14 @@ python devicetree_do_compile_append() {
 }
 
 do_install() {
-    install -d ${D}/lib/firmware/xilinx/${PN}/
-    install -Dm 0644 pl-final.dtbo ${D}/lib/firmware/xilinx/${PN}/${PN}.dtbo
-    install -Dm 0644 ${PN}.bit.bin ${D}/lib/firmware/xilinx/${PN}/${PN}.bit.bin
+    install -d ${D}${nonarch_base_libdir}/firmware/xilinx/${PN}/
+    install -Dm 0644 pl-final.dtbo ${D}${nonarch_base_libdir}/firmware/xilinx/${PN}/${PN}.dtbo
+    install -Dm 0644 ${PN}.bit.bin ${D}${nonarch_base_libdir}/firmware/xilinx/${PN}/${PN}.bit.bin
     if ls ${WORKDIR}/${XCL_PATH}/*.xclbin >/dev/null 2>&1; then
-        install -Dm 0644 ${WORKDIR}/${XCL_PATH}/*.xclbin ${D}/lib/firmware/xilinx/${PN}/${PN}.xclbin
+        install -Dm 0644 ${WORKDIR}/${XCL_PATH}/*.xclbin ${D}${nonarch_base_libdir}/firmware/xilinx/${PN}/${PN}.xclbin
     fi
 }
 
 do_deploy[noexec] = "1"
 
-FILES_${PN} += "/lib/firmware/xilinx/${PN}"
+FILES_${PN} += "${nonarch_base_libdir}/firmware/xilinx/${PN}"

--- a/recipes-bsp/fpga-manager-util/fpga-manager-util_1.0.bb
+++ b/recipes-bsp/fpga-manager-util/fpga-manager-util_1.0.bb
@@ -130,23 +130,23 @@ do_compile() {
 }
 
 do_install() {
-        install -d ${D}/lib/firmware/xilinx/base
+        install -d ${D}${nonarch_base_libdir}/firmware/xilinx/base
         if [ -e "base.dtbo" ]; then
             #install base hdf artifacts
-            install -Dm 0644 base.dtbo ${D}/lib/firmware/xilinx/base/base.dtbo
+            install -Dm 0644 base.dtbo ${D}${nonarch_base_libdir}/firmware/xilinx/base/base.dtbo
             if [ "${SOC_FAMILY}" != "versal" ]; then
                 newname=`basename *.bit.bin_base | awk -F '.bit.bin_' '{print $1}'`
-                install -Dm 0644 *.bit.bin_base ${D}/lib/firmware/xilinx/base/${newname}.bit.bin
+                install -Dm 0644 *.bit.bin_base ${D}${nonarch_base_libdir}/firmware/xilinx/base/${newname}.bit.bin
             else
                 #partial pdi in xsa is not yet supported, will need to modify this part once supported
                 echo "TODO"
             fi
         fi
         for hdf in ${HDF_LIST}; do
-                install -Dm 0644 ${hdf}.dtbo ${D}/lib/firmware/xilinx/${hdf}/${hdf}.dtbo
+                install -Dm 0644 ${hdf}.dtbo ${D}${nonarch_base_libdir}/firmware/xilinx/${hdf}/${hdf}.dtbo
                 if [ "${SOC_FAMILY}" != "versal" ]; then
                     newname=`basename *.bit.bin_${hdf} | awk -F '.bit.bin_' '{print $1}'`
-                    install -Dm 0644 *.bit.bin_${hdf} ${D}/lib/firmware/xilinx/${hdf}/${newname}.bit.bin
+                    install -Dm 0644 *.bit.bin_${hdf} ${D}${nonarch_base_libdir}/firmware/xilinx/${hdf}/${newname}.bit.bin
                 else
                     #partial pdi in xsa is not yet supported, will need to modify this part once supported
                     echo "TODO"
@@ -160,7 +160,7 @@ python () {
         if d.getVar('FPGA_MNGR_RECONFIG_ENABLE') == '1':
                 extra = d.getVar('EXTRA_HDF')
                 pn = d.getVar('PN')
-                baselib = d.getVar('base_libdir')
+                baselib = d.getVar('nonarch_base_libdir')
                 packages = d.getVar('PACKAGES').split()
 
                 #package base hdf


### PR DESCRIPTION
Fixes a packaging error when using 'usrmerge' in DISTRO_FEATURES
(nonarch_base_libdir is set to /usr/lib in this case, and to /lib when
 usrmerge is not used).

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>