### PR TITLE
aiefal: remove unneeded yocto-cmake-translation.class inherit. This c…

### DIFF
--- a/recipes-bsp/ai-engine/aiefal_1.0.bb
+++ b/recipes-bsp/ai-engine/aiefal_1.0.bb
@@ -16,7 +16,7 @@ IOBACKENDS ?= "Linux"
 PROVIDES = "aiefal"
 ALLOW_EMPTY_${PN} = "1"
 
-inherit pkgconfig cmake yocto-cmake-translation
+inherit pkgconfig cmake
 
 DEPENDS = "libxaiengine"
 


### PR DESCRIPTION
…lass is in meta-openamp and otherwise that layer is unnecessary for this one.