### PR TITLE
Fixed missing HDF dependencies

### DIFF
--- a/recipes-bsp/device-tree/device-tree.bbappend
+++ b/recipes-bsp/device-tree/device-tree.bbappend
@@ -7,6 +7,8 @@ require recipes-bsp/device-tree/device-tree.inc
 inherit xsctdt xsctyaml
 BASE_DTS ?= "system-top"
 
+DEPENDS += "virtual/hdf"
+
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 S = "${WORKDIR}/git"

--- a/recipes-bsp/embeddedsw/fsbl-firmware_2022.1.bbappend
+++ b/recipes-bsp/embeddedsw/fsbl-firmware_2022.1.bbappend
@@ -6,6 +6,8 @@ DEFAULT_PREFERENCE = "100"
 
 inherit xsctapp xsctyaml
 
+DEPENDS += "virtual/hdf"
+
 # This needs to match fsbl.bbappend
 FSBL_IMAGE_NAME = "fsbl-${MACHINE}"
 


### PR DESCRIPTION
Fixed missing dependencies, device-tree and fsbl-firmware are depend from hdf-external. If hdf-external has any changes then device-tree and fsbl-firmware could not re-built automatically and it cause run-time problem in boot. It was fixed in this commit.