### PR TITLE
pmu-firmware, fsbl-firmware: Fix build with `TCLIBC = "musl"`

### DIFF
--- a/classes/xsct-tc.bbclass
+++ b/classes/xsct-tc.bbclass
@@ -6,6 +6,7 @@ XSCT_PATH_ADD = "${XILINX_SDK_TOOLCHAIN}/bin:"
 # compiler, don't bother to build compilers for this...
 INHIBIT_DEFAULT_DEPS:linux = "1"
 INHIBIT_DEFAULT_DEPS:linux-gnueabi = "1"
+INHIBIT_DEFAULT_DEPS:linux-musl = "1"
 
 TC_XSCT_PATH = "\
 ${XILINX_SDK_TOOLCHAIN}/gnu/microblaze/lin/bin:\
@@ -15,6 +16,7 @@ ${XILINX_SDK_TOOLCHAIN}/gnu/aarch64/lin/aarch64-none/bin:"
 
 XSCT_PATH_ADD:append:linux = "${TC_XSCT_PATH}"
 XSCT_PATH_ADD:append:linux-gnueabi = "${TC_XSCT_PATH}"
+XSCT_PATH_ADD:append:linux-musl = "${TC_XSCT_PATH}"
 
 PATH =. "${XSCT_PATH_ADD}"
 TOOL_PATH = "${XILINX_SDK_TOOLCHAIN}/bin"

--- a/recipes-bsp/embeddedsw/fsbl-firmware_2022.2.bbappend
+++ b/recipes-bsp/embeddedsw/fsbl-firmware_2022.2.bbappend
@@ -30,6 +30,7 @@ COMPATIBLE_HOST:zynqmp = "${HOST_SYS}"
 # Clear this for a Linux build, using the XSCT toolchain
 EXTRA_OEMAKE:linux = ""
 EXTRA_OEMAKE:linux-gnueabi = ""
+EXTRA_OEMAKE:linux-musl = ""
 
 # Workaround for hardcoded toolchain items
 XSCT_PATH_ADD:append:elf = "\

--- a/recipes-bsp/embeddedsw/pmu-firmware_2022.2.bbappend
+++ b/recipes-bsp/embeddedsw/pmu-firmware_2022.2.bbappend
@@ -24,6 +24,8 @@ COMPATIBLE_HOST:zynqmp = "${HOST_SYS}"
 
 # Clear this for a Linux build, using the XSCT toolchain
 EXTRA_OEMAKE:linux = ""
+EXTRA_OEMAKE:linux-gnueabi = ""
+EXTRA_OEMAKE:linux-musl = ""
 
 # Workaround for hardcoded toolchain items
 XSCT_PATH_ADD:append:elf = "\


### PR DESCRIPTION
Both packages require toolchains outside normal build environment to target bare metal targets on MicroBlaze and ARM64 respectively. This patch fixes recipies to deal with that situation under musl environment as well.