### PR TITLE
dtgen_dfx: Fix -processor and -processor_ip parameter

### DIFF
--- a/scripts/dtgen_dfx.tcl
+++ b/scripts/dtgen_dfx.tcl
@@ -146,9 +146,28 @@ if { $params(ws) ne "" } {
 			platform read $params(ws)/$platname/platform.spr
 			platform remove $platname
 		}
-		set procs [getprocessors $params(hdf)]
-		if {[llength $procs] != 0} {
-			set processor [lindex $procs 0]
+
+		hsi::open_hw_design $params(hdf)
+		if { $params(processor) ne "" } {
+			set processor [lindex [hsi get_cells -hier -filter NAME==$params(processor)] 0]
+			if { $processor eq "" } {
+				puts "Error: No processor instance matching name '$params(processor)' found in static xsa file"
+			}
+		} elseif { $params(processor_ip) ne "" } {
+			set processor [lindex [hsi get_cells -hier -filter IP_NAME==$params(processor_ip)] 0]
+			if { $processor eq "" } {
+				puts "Error: No processor instance matching IP '$params(processor_ip)' found in static xsa file"
+			}
+		} else {
+			set procs [getprocessors $params(hdf)]
+			if {[llength $procs] != 0} {
+				set processor [lindex $procs 0]
+			} {
+				puts "Error: No processor instance found in static xsa file"
+			}
+		}
+
+		if { $processor ne "" } {
 			puts "INFO: Targeting Static XSA Processor is '$processor'"
 			if {$params(rphdf) eq ""} {
 				# Static xsa parsing
@@ -160,7 +179,7 @@ if { $params(ws) ne "" } {
 				-rm-hw $params(rphdf) -os device_tree -proc $processor -no-boot-bsp -out $params(ws)
 			}
 		} else {
-			puts "Error: No processor instance found in static xsa file"
+			puts "Error: Processor instance not set."
 		}
 
 		# Enable zocl by default when design is extensibale platform xsa


### PR DESCRIPTION
dtgen_dfx did not observe the -processsor or -processor_ip parameter but instead used always the first processor returned by getprocessors.

This fails, if the first processor has not the correct/expected architecture. For example, getprocessors could return "microblaze_I" as first element in a design for a ZynqMP Ultrascale+ with an embedded Microblaze processor, even though "-processor_ip psu_cortexa53" is being passed as parameter by the recipe/Openembedded build system.

With this change the script uses:
(1) the -processor parameter to find the given instance directly (2) the -processor_ip parameter to find instances with matching IP name (3) fall back to the previous behaviour of selecting the first entry of getprocessors.

Precedence is as listed, i.e. if -processor is given, -processor_ip is ignored.

This fixes #54